### PR TITLE
degville's Juju docs help scripts

### DIFF
--- a/scripts-gm/README.md
+++ b/scripts-gm/README.md
@@ -1,0 +1,15 @@
+# Juju Documentation Help Scripts
+
+## jmd
+Execute juju with provided arguments and encapsulate output for use within
+markdown documentation.
+
+## jjdiff
+Generate a folder named after a version of Juju that contains the help text for
+every internal juju command.
+
+## juju-pr-parser.js
+
+Google App Script that scans Juju Github notification emails in Gmail labelled
+with `git juju/core` and extracts sections called `Documentation Changes`,
+placing them into a GDrive spreadsheet.

--- a/scripts-gm/jjdiff
+++ b/scripts-gm/jjdiff
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+import argparse
+import subprocess
+import os, sys
+
+JUJUEXE = "juju"
+
+def parse_args(parser, args=None):
+#    if args is None:
+#        args = sys.argv[1:]
+    return parser.parse_args(args)
+
+
+def main():
+   parser = argparse.ArgumentParser(description='Generates an internal list of currently supported commands and compares them against different versions of Juju.')
+   parser.add_argument('jujuargs', nargs=argparse.REMAINDER)
+   args = parse_args(parser)
+
+   # Get version string
+   jujuversion = subprocess.check_output([JUJUEXE, 'version'], universal_newlines=False)
+
+   # Run Juju with arguments
+   #jujuoutput = subprocess.check_output([JUJUEXE] + args.jujuargs)
+
+   jujuoutput = subprocess.check_output([JUJUEXE, 'help', 'commands'])
+
+   # Remove byte code andsssss feed
+   jujuversion = bytes.decode(jujuversion)
+   jujuversion = jujuversion.strip('\n')
+   jujuvnumber = jujuversion.split('-',1)[0]
+
+   jujuoutput = bytes.decode(jujuoutput)
+   jujuoutput = jujuoutput[:-1]
+
+   # Create folder to hold versioned help files
+   if not os.path.exists(jujuvnumber):
+       os.makedirs(jujuvnumber)
+
+   for line in jujuoutput.splitlines():
+       parseHelpLine(jujuvnumber, line)
+
+   # Create folder to hold versioned help files
+   if not os.path.exists(jujuvnumber):
+       os.makedirs(jujuvnumber)
+   
+   # Create a text file containing the command help 
+   with open((os.path.join(jujuvnumber,"commands")), "w") as command_file:
+       command_file.write(jujuoutput)
+   
+   # Create a text file containing the version 
+   with open((os.path.join(jujuvnumber,"VERSION")), "w") as command_file:
+       command_file.write(jujuvnumber)
+
+
+   # Output
+   # print ("<!-- JUJUVERSION: " + jujuversion + " -->")
+
+def parseHelpLine(version, line):
+   singlecommand = line.split(' ',1)[0]
+   commandoutput = subprocess.check_output([JUJUEXE,'help', singlecommand])
+   commandoutput = bytes.decode(commandoutput)
+   
+   # Create folder to hold versioned help files
+   if not os.path.exists(version):
+       os.makedirs(version)
+
+   # Create a text file containing the help for each command
+   with open((os.path.join(version,singlecommand)), "w") as command_file:
+       command_file.write(commandoutput)
+
+if __name__ == '__main__':
+    main()

--- a/scripts-gm/jmd
+++ b/scripts-gm/jmd
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import argparse
+import subprocess
+import sys
+
+JUJUEXE = "juju"
+ENCSTRING = "no-highlight"
+
+def parse_args(parser, args=None):
+#    if args is None:
+#        args = sys.argv[1:]
+    return parser.parse_args(args)
+
+
+def main():
+   parser = argparse.ArgumentParser(description='Execute juju with provided arguments and encapsulate output for use within markdown documentation.')
+   parser.add_argument('jujuargs', nargs=argparse.REMAINDER)
+   args = parse_args(parser)
+
+   # Get version string
+   jujuversion = subprocess.check_output([JUJUEXE, 'version'], universal_newlines=False)
+
+   # Run Juju with arguments
+   jujuoutput = subprocess.check_output([JUJUEXE] + args.jujuargs)
+
+   # Remove byte code andsssss feed
+   jujuversion = bytes.decode(jujuversion)
+   jujuversion = jujuversion.strip('\n')
+
+   jujuoutput = bytes.decode(jujuoutput)
+   jujuoutput = jujuoutput[:-1]
+
+   # Output
+   print ("<!-- JUJUVERSION: " + jujuversion + " -->")
+   print ("<!-- JUJUCOMMAND: " + JUJUEXE + " " + " ".join(args.jujuargs) + " -->")
+   print ("```" + ENCSTRING)
+   print (jujuoutput)
+   print ("```")
+
+if __name__ == '__main__':
+    main()

--- a/scripts-gm/juju-pr-parser.js
+++ b/scripts-gm/juju-pr-parser.js
@@ -1,0 +1,100 @@
+// Google App Script
+// Scans Juju Github notification emails in Gmail labelled with 'git juju/core'
+// and extracts Documentation Changes, placing them into a GDrive spreadsheet.
+
+// TODO: split into functions
+
+function myFuction(){
+
+  var ss = SpreadsheetApp.openById(PLACE-SPREADSHEET-ID-HERE);
+  var ss = ss.getSheetByName("Merges");
+
+  // Grab unread threads with specific label
+  var threads = GmailApp.search("label: 'git juju/core' is:unread");
+
+  // Look for threads where documentation is required
+  for (var t in threads) {
+    
+    var thread = threads[t];
+
+    // Get message details for first message in thread
+    var mesg = thread.getMessages()[0].getPlainBody();
+    
+    // Search to see if there's a doc changes section
+    var start_match = mesg.match(/(Documentation changes)/gi);
+    
+    if (start_match != null){
+    
+      // extract doc changes
+      var firstIndex = mesg.indexOf(start_match[0]);
+      firstIndex = firstIndex + 21;
+      // TODO: this needs smartening up, as bug reference could appear before doc changes
+      var end_match = mesg.match(/(Bug reference|You can view, comment on, or merge this pull request)/gi);
+      
+      if (end_match != null){
+        var lastIndex = mesg.indexOf(end_match[0], firstIndex);
+        lastIndex = lastIndex - 3;
+      } else {
+        var lastIndex = mesg.length; 
+      }
+      
+      var foundText = mesg.substring(firstIndex, lastIndex);
+      
+        // strip line breaks from the document changes description
+      foundText = foundText.replace(/(\r\n|\n|\r)/gm, "");
+  
+      // check whether text is an excuse
+      var doc_exempt = foundText.match(/^(N\/A|No|N.A.|NA|None|None.|\n|^$|Does it affect current user workflow\? CLI\? API\?|Does it affect current user workflow\? No  CLI\? No  API\? No|> Does it affect current user workflow\? CLI? API\?No.)/i);
+      
+      if (doc_exempt == null){
+      
+        // format date
+        var subj = thread.getMessages()[0].getSubject();
+        var date = Utilities.formatDate(thread.getMessages()[0].getDate(),"GMT","yyyy-MM-dd");
+  
+        // Extract the merge number from the subject
+        // TODO: needs tuning - currently only looks/extracts 4 digit issue nos. like this: (#1234)
+        var issue_raw = subj.match(/(\(#)(?:\d{4})(\))/g);
+        
+        if (issue_raw != null){
+          
+          var issue = issue_raw[0].match(/(?:\d{4})/g) || ['Not valid'];
+    
+          // Add a hyperlink to the issue number
+          var url = "https://github.com/juju/juju/pull/";
+          var formula = '=HYPERLINK("' + url + issue +'", "' + issue[0] + '")';
+        } else {
+         var formula = "Not found" 
+        }
+        
+        // look for duplicates and only add new row if none are found
+        var data=ss.getDataRange().getValues();
+        var duplicate = false;
+        
+        var rows;
+        
+        for(i in data){
+          
+          if(data[i][1] == issue[0]){
+            duplicate = true;
+          } 
+        }
+        
+        if (!duplicate)
+          ss.appendRow([date, formula, "", subj, foundText]);
+      } 
+    }
+    // mark thread as unread
+    GmailApp.markThreadRead(thread);
+  }
+  
+  // sort sheet after updates
+  var range = ss.getDataRange();
+  
+  range.sort( {
+    column: 2,
+    ascending: false
+  } );
+   
+}
+


### PR DESCRIPTION
## jmd
Execute juju with provided arguments and encapsulate output for use within markdown documentation.

## jjdiff
Generate a folder named after a version of Juju that contains the help text for every internal juju command.

## juju-pr-parser.js

Google App Script that scans Juju Github notification emails in Gmail labelled with `git juju/core` and extracts sections called `Documentation Changes`, placing them into a GDrive spreadsheet.